### PR TITLE
Feat: Set access control level

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Options:
   -g, --glob           A glob on filename level to filter the files to upload                  [string] [default: "*.*"]
   -a, --cache-control  Cache control for uploaded files, can be string for single value or list of glob settings
                                                                                                   [string] [default: ""]
+  -acl, --access-control-level  Sets the access control level for uploaded files
+                                                                                                  [string] [default: "undefined"]
   -c, --config         The AWS config json path to load S3 credentials with loadFromPath.                       [string]
   -h, --help           Show help                                                                               [boolean]
 
@@ -75,7 +77,8 @@ await new Uploader({
     '**/settings.json': 'max-age=60', // 1 mins for settings, specific matches should go first
     '**/*.json': 'max-age=300', // 5 mins for other jsons
     '**/*.*': 'max-age=3600', // 1 hour for everthing else
-  } 
+  },
+  accessControlLevel: 'bucket-owner-full-control' // optional, not passed if undefined. - available options - "private"|"public-read"|"public-read-write"|"authenticated-read"|"aws-exec-read"|"bucket-owner-read"|"bucket-owner-full-control"
 }).upload();
 ```
 
@@ -88,8 +91,8 @@ in your repo. Use the following template for the config file as stated in the [A
 
 ```json
 {
-  "accessKeyId": "<YOUR_ACCESS_KEY_ID>", 
-  "secretAccessKey": "<YOUR_SECRET_ACCESS_KEY>", 
+  "accessKeyId": "<YOUR_ACCESS_KEY_ID>",
+  "secretAccessKey": "<YOUR_SECRET_ACCESS_KEY>",
   "region": "us-east-1"
 }
 ```

--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -64,6 +64,13 @@ yargs
     type: 'string',
     nargs: 1,
   })
+  .option('acl', {
+    alias: 'access-control-level',
+    default: undefined,
+    describe: 'Sets the bucket access control level for uploaded files',
+    type: 'string',
+    nargs: 1,
+  })
   .option('a', {
     alias: 'cache-control',
     default: '',

--- a/test/Uploader.spec.ts
+++ b/test/Uploader.spec.ts
@@ -46,6 +46,43 @@ describe('Uploader', () => {
       (<any>s3.upload).restore();
     });
 
+    it('should upload with access control level options', async function() {
+      this.timeout(10000);
+
+      const s3 = {
+        upload(_, cb) {
+          cb(null);
+        }
+      };
+      spy(s3, "upload");
+
+      uploader = new Uploader({
+        localPath: 'test/files',
+        remotePath: 'fake',
+        bucket: 'fake',
+        glob: '**/demo.png',
+        s3Client: <any>s3,
+        accessControlLevel: 'bucket-owner-full-control'
+      });
+
+      await uploader.upload();
+
+      const { Body, ...args} = (<any>s3.upload).lastCall.args[0];
+
+
+      expect(args).to.deep.equal({
+        ACL: 'bucket-owner-full-control',
+        Bucket: 'fake',
+        Key: 'fake/demo.png',
+        ContentType: 'image/png',
+        CacheControl: '',
+      });
+
+      (<any>expect(Body).to.be.a).ReadableStream;
+
+      (<any>s3.upload).restore();
+    });
+
     it('should fix windows paths', async function() {
       this.timeout(5000);
 


### PR DESCRIPTION
closes #3 

Feature Request

Allow setting of ACL permissions on uploaded artefacts.

Tested in my local project, uploaded a video file to my bucket,

https://cypress-slack-reporter.s3.amazonaws.com/cypress/videos/small.mp4

Returns  the following when no `accessControlLevel` is set in options

```
<Error>
<Code>AccessDenied</Code>
<Message>Access Denied</Message>
<RequestId>3418E84327DA284B</RequestId>
<HostId>
pmv0RkSrWHcK1PgSJjGASttH8Fanmv9SVZgESwqQiALyIYpYn3OqVu5npo8vh+ARSfMAL+lkfyM=
</HostId>
</Error>
```

But I can still sync, when logged in as me (bucket owner)

```
➜  s3-batch-upload git:(accessLevelControl) aws s3 sync s3://cypress-slack-reporter/cypress/videos .
download: s3://cypress-slack-reporter/cypress/videos/small.mp4 to ./small.mp4
```

But not when I am under another AWS role

```
➜  s3-batch-upload git:(accessLevelControl) aws s3 sync s3://cypress-slack-reporter/cypress/videos .     
fatal error: An error occurred (AccessDenied) when calling the ListObjectsV2 operation: Access Denied
```

Returns the video, when `accessControlLevel` is set to "public-read" - It is currently set to that, so you should be able to view the video :)

