### PR TITLE
Add `overwrite` option to skip existing files

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Examples:
   cli.js ... -a '{ "**/*.json": "max-age=300", "**/*.*":       Upload files from a local folder to a s3 bucket path
   "max-age=3600" }'
   cli.js ... -g "*" --go.nodir true --go.dot true               Upload files from a local folder (including files with or without extension and .dot files)
+  cli.js --no-overwrite ...                                     Skip uploading files which exist already on s3
   cli.js -d ...                                                 Dry run upload
 
 for more information about AWS authentication, please visit

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Options:
   -acl, --access-control-level  Sets the access control level for uploaded files
                                                                                                   [string] [default: "undefined"]
   -c, --config         The AWS config json path to load S3 credentials with loadFromPath.                       [string]
+  -o, --overwrite      Overwrite remote files with the same name, or skip them.                [boolean] [default: true]
   -h, --help           Show help                                                                               [boolean]
 
 Examples:
@@ -81,6 +82,7 @@ const files = await new Uploader({
     '**/*.json': 'max-age=300', // 5 mins for other jsons
     '**/*.*': 'max-age=3600', // 1 hour for everthing else
   },
+  overwrite: false, // overwrite remote files with the same name, default is true
   accessControlLevel: 'bucket-owner-full-control' // optional, not passed if undefined. - available options - "private"|"public-read"|"public-read-write"|"authenticated-read"|"aws-exec-read"|"bucket-owner-read"|"bucket-owner-full-control"
 }).upload();
 

--- a/src/lib/Uploader.ts
+++ b/src/lib/Uploader.ts
@@ -160,17 +160,15 @@ export default class Uploader {
       params.ACL = ACL;
     }
 
-    return new Promise(resolve => {
-      if (!dryRun) {
-        this.s3.upload(params, err => {
-          // tslint:disable-next-line no-console
-          if (err) console.error('err:', err);
-          resolve(params.Key);
-        });
-      } else {
-        resolve(params.Key);
+    if (!dryRun) {
+      try {
+        await this.s3.upload(params).promise();
+      } catch (err) {
+        // tslint:disable-next-line no-console
+        console.error('err:', err);
       }
-    });
+    }
+    return params.Key;
   }
 
   /**

--- a/src/lib/Uploader.ts
+++ b/src/lib/Uploader.ts
@@ -23,7 +23,7 @@ export type Options = {
   cacheControl?: string | { [key: string]: string };
   s3Client?: S3;
   accessControlLevel?: S3.ObjectCannedACL;
-  allowOverwrite?: boolean;
+  overwrite?: boolean;
 };
 
 const defaultOptions = {
@@ -31,7 +31,7 @@ const defaultOptions = {
   concurrency: 100,
   glob: '*.*',
   globOptions: {},
-  allowOverwrite: true,
+  overwrite: true,
 };
 
 export default class Uploader {
@@ -135,7 +135,7 @@ export default class Uploader {
       Bucket,
       Key: remotePath.replace(/\\/g, '/'),
     };
-    if (!this.options.allowOverwrite) {
+    if (!this.options.overwrite) {
       try {
         await this.s3.headObject(baseParams).promise();
         // tslint:disable-next-line no-console
@@ -145,6 +145,7 @@ export default class Uploader {
         if (err.code !== 'NotFound') {
           // tslint:disable-next-line no-console
           console.error('err:', err);
+          throw err;
         }
       }
     }

--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -22,6 +22,7 @@ yargs
     '$0 ... -a \'{ "**/*.json": "max-age=300", "**/*.*": "max-age=3600" }\'',
     'Upload files from a local folder to a s3 bucket path',
   )
+  .example('$0 --no-overwrite ...', 'Skip uploading files which exist already on s3')
   .example('$0 -d ...', 'Dry run upload')
   .option('d', {
     alias: 'dry-run',
@@ -106,9 +107,9 @@ yargs
   .option('o', {
     alias: 'overwrite',
     default: true,
-    describe: 'Overwrite remote files with the same name, or skip them.',
+    describe:
+      'Overwrite remote files with the same name (default behavior), or skip them with --no-overwrite.',
     type: 'boolean',
-    nargs: 1,
   })
   .demandOption(
     ['bucket', 'local-path', 'remote-path'],

--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -103,6 +103,13 @@ yargs
     type: 'string',
     nargs: 1,
   })
+  .option('o', {
+    alias: 'overwrite',
+    default: true,
+    describe: 'Overwrite remote files with the same name, or skip them.',
+    type: 'boolean',
+    nargs: 1,
+  })
   .demandOption(
     ['bucket', 'local-path', 'remote-path'],
     'Please provide at least the required arguments to upload.',


### PR DESCRIPTION
Hi, we use `s3-batch-upload` to upload files with content hash in their name (e.g. bundled assets from Webpack). I wanted to avoid overwriting files which are already uploaded. Basically if the file exists on the remote end, we are sure that it's the same file – no need to check MD5 or mtime.

Perhaps this feature is too much specific to our use case, but I was going to implement it anyways, so I thought why not propose it to the upstream.

I have added option `overwrite` with default set to `true`. If you set it to `false`, the uploader will first perform `headObject` on the remote end to check if the file exists and if it does, it won't upload it. This could be eventually expanded to e.g. accept a function which determines whether the file should be overwritten or not.

I still need to properly document it, but the code is ready for review, including tests.